### PR TITLE
US-M2 Student Project

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "github-pages", group: :jekyll_plugins
+# gem "github-pages", group: :jekyll_plugins
 
 # If you want to use Jekyll native, uncomment the line below.
 # To upgrade, run `bundle update`.

--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,8 @@ home:
 
 collections:
   - "team"
+  - "projects"
+  - "sprojects"
 
 defaults:
   - scope:

--- a/_includes/project-card.html
+++ b/_includes/project-card.html
@@ -1,0 +1,34 @@
+<a href="">
+
+  <div class="project-card">
+
+    <div>
+      <h3 class="title">{{ project.title }}</h3>
+      <p class="category">{{ project.category }}</p>
+    </div>
+
+    <!--TODO: add a CMS field for short description-->
+    <p class="description">{{ project.short_description }}</p>
+
+    <div class="details-container">
+      <div class="detail">
+        <p class="name">Status</p>
+        <p>
+          {% if project.available %}
+          <span>Available</span>
+          {% else %}
+          <span>Unavailable</span>
+          {% endif %}
+        </p>
+      </div>
+      <div class="detail">
+        <p class="name">Types</p>
+        <p>
+          {% for type in project.types %}
+          <span>{{ type }},</span>
+          {% endfor %}
+        </p>
+      </div>
+    </div>
+  </div>
+</a>

--- a/_includes/project-card.html
+++ b/_includes/project-card.html
@@ -11,7 +11,7 @@
 
     <!--TODO: add a CMS field for short description-->
     <p class="description">
-      {% if project.short %}
+      {% if project.short != "" %}
         {{ project.short }}
       {% else %}
         No short project description has been provided for this project.

--- a/_includes/project-card.html
+++ b/_includes/project-card.html
@@ -32,6 +32,7 @@
       <div class="detail">
         <p class="name">Types</p>
         <p>
+          <!--TODO: get rid of trailing commas-->
           {% for type in project.types %}
           <span>{{ type }},</span>
           {% endfor %}

--- a/_includes/project-card.html
+++ b/_includes/project-card.html
@@ -10,7 +10,9 @@
     </div>
 
     <!--TODO: add a CMS field for short description-->
-    <p class="description">{{ project.short_description }}</p>
+    <p class="description">
+        {{ project.short }}
+    </p>
 
     <div class="details-container">
       <div class="detail">

--- a/_includes/project-card.html
+++ b/_includes/project-card.html
@@ -11,7 +11,11 @@
 
     <!--TODO: add a CMS field for short description-->
     <p class="description">
+      {% if project.short %}
         {{ project.short }}
+      {% else %}
+        No short project description has been provided for this project.
+      {% endif %}
     </p>
 
     <div class="details-container">

--- a/_includes/project-card.html
+++ b/_includes/project-card.html
@@ -1,10 +1,12 @@
 <a href="">
-
   <div class="project-card">
 
-    <div>
-      <h3 class="title">{{ project.title }}</h3>
-      <p class="category">{{ project.category }}</p>
+    <h3 class="title">{{ project.title }}</h3>
+
+    <div class="keywords">
+      {% for keyword in project.keywords %}
+        <span>{{ keyword }}</span>
+      {% endfor %}
     </div>
 
     <!--TODO: add a CMS field for short description-->

--- a/_layouts/education.html
+++ b/_layouts/education.html
@@ -29,14 +29,10 @@ bodyClass: "page-education"
     </div>
   -->
 
-  <h2>Student Projects</h2>
-  <div class="container">
-    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 align-items-strech g-1 gy-2">
-      {% for project in site.sprojects %}
-        <div class="col mb-3">
-          {% include project-card.html project=project %}
-        </div>
-      {% endfor %}
-    </div>
-  </div >
+  <h2 class="mb-3">Student Projects</h2>
+  <div class="d-flex flex-wrap" style="gap: 15px">
+    {% for project in site.sprojects %}
+      {% include project-card.html project=project %}
+    {% endfor %}
+  </div>
 </div>

--- a/_layouts/education.html
+++ b/_layouts/education.html
@@ -21,8 +21,22 @@ bodyClass: "page-education"
 -->
 
 <div class="container pb-6 pt-6 pt-md-10 pb-md-10">
-  <h1 class="title">{{page.title}}</h1>
-  <div class="content mt-4">
-    {{ content }}
-  </div>
+  <h1 class="title">{{ page.title }}</h1>
+
+  <!--
+    <div class="content mt-4">
+      {{ content }}
+    </div>
+  -->
+
+  <h2>Student Projects</h2>
+  <div class="container">
+    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 align-items-strech g-1 gy-2">
+      {% for project in site.sprojects %}
+        <div class="col mb-3">
+          {% include project-card.html project=project %}
+        </div>
+      {% endfor %}
+    </div>
+  </div >
 </div>

--- a/_sass/components/_project-card.scss
+++ b/_sass/components/_project-card.scss
@@ -3,8 +3,10 @@
 }
 
 .project-card {
-  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
 
+  padding: 1.25rem 1.5rem;
   box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.1) 0px 4px 6px -4px;
 
   // set border styles
@@ -12,6 +14,8 @@
   border-width: 1px;
   border-radius: 0.75rem;
   border-color: #e5e7eb;
+  max-width: 32rem;
+  height: 100%;
 
   transition: transform;
   transition-duration: 100ms;
@@ -61,6 +65,7 @@
     padding-top: 0.75rem;
     padding-bottom: 1rem;
     color: black;
+    flex-grow: 1;
   }
 
   .details-container {

--- a/_sass/components/_project-card.scss
+++ b/_sass/components/_project-card.scss
@@ -21,6 +21,27 @@
     margin: 0px;
   }
 
+  .keywords {
+    margin-top: 0.5rem;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 5px;
+
+    span {
+      white-space: nowrap;
+      border-radius: 9999px;
+      padding-left: 0.625rem;
+      padding-right: 0.625rem;
+      font-size: 0.875rem;
+      line-height: 1.25rem;
+      padding-top: 0.125rem;
+      padding-bottom: 0.125rem;
+      background-color: rgb(254, 226, 226);
+      color: rgb(185, 28, 28);
+    }
+  }
+
   // default font size for component
   font-size: 1rem;
   line-height: 1.5rem;
@@ -34,11 +55,6 @@
     font-size: 1.25rem;
     line-height: 1.75rem;
     font-weight: 600;
-  }
-
-  .category {
-    color: #4B5563;
-    font-weight: 400;
   }
 
   .description {

--- a/_sass/components/_project-card.scss
+++ b/_sass/components/_project-card.scss
@@ -1,0 +1,71 @@
+.project-card:hover {
+  transform: scale(1.0125) translateY(-5px);
+}
+
+.project-card {
+  padding: 1.25rem 1.5rem;
+
+  box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.1) 0px 4px 6px -4px;
+
+  // set border styles
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.75rem;
+  border-color: #e5e7eb;
+
+  transition: transform;
+  transition-duration: 100ms;
+  transition-timing-function: ease-out;
+
+  p {
+    margin: 0px;
+  }
+
+  // default font size for component
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 400;
+
+  background-color: white;
+  //background-color: #F3F4F6;
+
+  .title {
+    margin: 0px;
+    font-size: 1.25rem;
+    line-height: 1.75rem;
+    font-weight: 600;
+  }
+
+  .category {
+    color: #4B5563;
+    font-weight: 400;
+  }
+
+  .description {
+    padding-top: 0.75rem;
+    padding-bottom: 1rem;
+    color: black;
+  }
+
+  .details-container {
+    display: flex;
+    gap: 1.5rem;
+  }
+
+  .detail {
+    display: flex;
+    flex-direction: column;
+    min-width: 100px;
+  }
+
+  .detail>:first-child {
+    font-size: 0.875rem;
+    line-height: 1.25rem;
+  }
+
+  .detail>:last-child {
+    font-weight: 500;
+    color: #374151; // text-gray-700
+    // color: #111827; // text-gray-900
+  }
+}

--- a/_sass/components/_project-card.scss
+++ b/_sass/components/_project-card.scss
@@ -43,6 +43,10 @@
       padding-bottom: 0.125rem;
       background-color: rgb(254, 226, 226);
       color: rgb(185, 28, 28);
+
+      /*  Enforce capitalized words since user defined keywords are inconsistent.
+          TODO: maybe remove this once CMS is in place? */
+      text-transform: capitalize;
     }
   }
 

--- a/_sprojects/andrikopoulos-1.md
+++ b/_sprojects/andrikopoulos-1.md
@@ -12,6 +12,8 @@ types:
   - MSc Int
   - MSc
 posted: 2023-02-10
+# TODO: replace this description with an approved one
+short: "We are offering a series of projects under the umbrella of mining cloud cost awareness, that is, of software developers being aware of the costs of deploying and operating cloud-based software."
 supervisors:
   - name: "Vasilios Andrikopoulos"
     email: "v.andrikopoulos@rug.nl"

--- a/_sprojects/andrikopoulos-2.md
+++ b/_sprojects/andrikopoulos-2.md
@@ -1,9 +1,10 @@
 ---
 title: "A Survey of Cloud Cost Calculators"
 category: "Software & Architecture Analytics Projects"
+short: ""
 keywords:
   - Cloud Computing
-  - Cost 
+  - Cost
 is_group: false
 available: true
 types:
@@ -17,6 +18,7 @@ supervisors:
 The utility computing-oriented billing of cloud services means that users of these services get charged over time and intensity of use in a similar manner to public utilities such as electricity or phones. As a result, both researchers and practitioners have become interested on developing tools calculating the cost of their software on cloud services before they are even actually deployed and ran there. This project aims to survey existing approaches from both research (through e.g. a literature review) and practice (by means of locating and examining open source cost calculator projects) in order to compare and contrast these approaches, forming the State of the Art on the topic.
 
 Literature
+
 - The NIST definition of cloud computing
 - A view of cloud computing
 - Why Adopting Cloud Is Still a Challenge?—A Review on Issues and Challenges for Cloud Migration in Organizations

--- a/_sprojects/andrikopoulos-3.md
+++ b/_sprojects/andrikopoulos-3.md
@@ -1,6 +1,7 @@
 ---
 title: "Establishing the environmental footprint of chatbots"
 category: "Software & Architecture Analytics Projects 2022-23"
+short: ""
 keywords:
   - Cloud Computing
   - Sustainability

--- a/_sprojects/andrikopoulos-4.md
+++ b/_sprojects/andrikopoulos-4.md
@@ -1,6 +1,7 @@
 ---
 title: "Establishing the environmental footprint of chatbots"
 category: "Software & Architecture Analytics Projects 2022-23"
+short: ""
 keywords:
   - Cloud Computing
   - Sustainability

--- a/_sprojects/avgeriou-soliman-1.md
+++ b/_sprojects/avgeriou-soliman-1.md
@@ -1,6 +1,7 @@
 ---
 title: "Develop a Web-Based Self-Admitted Technical Debt Visualization and Management System"
 category: "Software & Architecture Analytics Projects"
+short: ""
 keywords:
   - software engineering
   - empirical studies
@@ -24,14 +25,14 @@ Technical debt refers to taking shortcuts, either deliberately or inadvertently,
 
 A part of technical debt is declared by the developers themselves (i.e., self-admitted technical debt). For instance, a developer found low-quality code, which complicates debugging; thus, he created a new ticket in the issue tracker to resolve the found code debt (code debt is a type of technical debt that results from poorly-written code; other types of debt are defined in the work of Alves et al. [1]):
 
->   If the user doesn't setup the right camel context for the context component.
->   The exception we got is misleading, we need to throw more meaningful 
->   exception for it. - [Camel-5714]
+> If the user doesn't setup the right camel context for the context component.
+> The exception we got is misleading, we need to throw more meaningful
+> exception for it. - [Camel-5714]
 
 In another case, during a code review in issues, a developer found that a shortcut was taken. Thus, he commented the technical debt on a patch:
 
->   The patch looks good to me... It would be better if we can add an upper limit
->   for the size of the GSet. - [Hadoop-9763]
+> The patch looks good to me... It would be better if we can add an upper limit
+> for the size of the GSet. - [Hadoop-9763]
 
 Technical debt statement examples shown above are identified and reported by developers in the JIRA issue tracker. Some of them are repaid while some are not. In order to better manage technical debt, we need to design and develop a visualization and management system to help developers manage self-admitted technical debt.
 
@@ -41,4 +42,4 @@ If you are interested in this project, please contact us for project detail info
 
 [1] Nicolli SR Alves, Leilane F Ribeiro, Vivyane Caires, Thiago S Mendes, and Rodrigo O Spínola. 2014. Towards an ontology of terms on technical debt. In 2014 Sixth International Workshop on Managing Technical Debt. IEEE, 1–7.
 
-[2] Paris Avgeriou, Philippe Kruchten, Ipek Ozkaya, and Carolyn Seaman. 2016. Managing Technical Debt in Software Engineering (Dagstuhl Seminar 16162). Dagstuhl Reports 6, 4 (2016), 110–138. https://doi.org/10.4230/DagRep.6.4.110
+[2] Paris Avgeriou, Philippe Kruchten, Ipek Ozkaya, and Carolyn Seaman. 2016. Managing Technical Debt in Software Engineering (Dagstuhl Seminar 16162). Dagstuhl Reports 6, 4 (2016), 110–138. <https://doi.org/10.4230/DagRep.6.4.110>

--- a/_sprojects/avgeriou-soliman-2.md
+++ b/_sprojects/avgeriou-soliman-2.md
@@ -1,6 +1,7 @@
 ---
 title: "Design and Implementation of a Technical Debt Monitoring System for PHP"
 category: "Software & Architecture Analytics Projects"
+short: ""
 keywords:
   - software engineering
   - empirical studies

--- a/_sprojects/capiluppi-3.md
+++ b/_sprojects/capiluppi-3.md
@@ -1,6 +1,7 @@
 ---
 title: "Extracting, Indexing and Listing Replication Packages from Past Research"
 category: "ML, NLP and Refactoring Projects 2022-23"
+short: ""
 keywords:
   - NLP
   - machine learning

--- a/_sprojects/feitosa-1.md
+++ b/_sprojects/feitosa-1.md
@@ -1,6 +1,7 @@
 ---
 title: "Upgrade Design Pattern Detector and Quality Assessment"
 category: "ML, NLP and Refactoring Projects 2022-23"
+short: ""
 keywords:
   - refactoring
   - design patterns
@@ -25,4 +26,5 @@ The SEARCH group has built two tools to support the measurement of pattern grime
 This project entail the **refactoring and upgrade** (incl. dependencies' update and small bug fixes) of both SSAP and Spoon-PttGrime. It can be taken as one or two Short Programming Projects (**SPP**) (depending on the level of refactoring), or a **master's intership**.
 
 # References
-- [1] Daniel Feitosa, Apostolos Ampatzoglou, Paris Avgeriou, and Elisa Y Nakagawa. 2018. Correlating Pattern Grime and Quality Attributes. In IEEE Access, vol. 6, pp. 23065-23078. https://doi.org/10.1109/ACCESS.2018.2829895.
+
+- [1] Daniel Feitosa, Apostolos Ampatzoglou, Paris Avgeriou, and Elisa Y Nakagawa. 2018. Correlating Pattern Grime and Quality Attributes. In IEEE Access, vol. 6, pp. 23065-23078. <https://doi.org/10.1109/ACCESS.2018.2829895>.

--- a/_sprojects/feitosa-2.md
+++ b/_sprojects/feitosa-2.md
@@ -1,6 +1,7 @@
 ---
 title: "Is Design Pattern Grime Related to Technical Debt?"
 category: "Software & Architecture Analytics Projects"
+short: ""
 keywords:
   - mining software repositories
   - empirical studies
@@ -25,6 +26,6 @@ As you may have guessed by now, the main goal of this project is to find to what
 
 This project is offered as a group BSc thesis or a single MSc thesis.
 
-[1] Daniel Feitosa, Apostolos Ampatzoglou, Paris Avgeriou, and Elisa Y Nakagawa. 2018. Correlating Pattern Grime and Quality Attributes. In IEEE Access, vol. 6, pp. 23065-23078. https://doi.org/10.1109/ACCESS.2018.2829895.
+[1] Daniel Feitosa, Apostolos Ampatzoglou, Paris Avgeriou, and Elisa Y Nakagawa. 2018. Correlating Pattern Grime and Quality Attributes. In IEEE Access, vol. 6, pp. 23065-23078. <https://doi.org/10.1109/ACCESS.2018.2829895>.
 
-[2] Paris Avgeriou, Philippe Kruchten, Ipek Ozkaya, and Carolyn Seaman. 2016. Managing Technical Debt in Software Engineering (Dagstuhl Seminar 16162). Dagstuhl Reports 6, 4 (2016), 110–138. https://doi.org/10.4230/DagRep.6.4.110
+[2] Paris Avgeriou, Philippe Kruchten, Ipek Ozkaya, and Carolyn Seaman. 2016. Managing Technical Debt in Software Engineering (Dagstuhl Seminar 16162). Dagstuhl Reports 6, 4 (2016), 110–138. <https://doi.org/10.4230/DagRep.6.4.110>

--- a/_sprojects/feitosa-3.md
+++ b/_sprojects/feitosa-3.md
@@ -1,6 +1,7 @@
 ---
 title: "Software Mining Rig: Building a Scalable MSR Infrastructure for Research"
 category: "Software & Architecture Analytics Projects 2022-23"
+short: ""
 keywords:
   - mining software repositories
   - software analytics

--- a/_sprojects/rastogi-1.md
+++ b/_sprojects/rastogi-1.md
@@ -2,17 +2,17 @@
 title: "How does software change?"
 category: "Software & Architecture Analytics Projects"
 keywords:
-- software engineering
-- empirical research
-- data science
-  is_group: false
-  available: true
-  types:
-- MSc
-  posted: 2023-01-01
-  supervisors:
-- name: "Ayushi Rastogi"
-  email: "a.rastogi@rug.nl"
+  - software engineering
+  - empirical research
+  - data science
+is_group: false
+available: true
+types:
+  - MSc
+posted: 2023-01-01
+supervisors:
+  - name: "Ayushi Rastogi"
+    email: "a.rastogi@rug.nl"
 ---
 As Lehman's first law of software evolution states: a [...] system must be continually adapted or it becomes progressively less satisfactory". With software systems shaping humans, it is increasingly important to understand their evolution.
 There are many parts of this project, offering interesting and challenging opportunities at the intersection of software engineering and artificial intelligence. This project will harness the ability to gather signals from data to infer meaningful insights and inform decisions

--- a/_sprojects/rastogi-1.md
+++ b/_sprojects/rastogi-1.md
@@ -1,6 +1,7 @@
 ---
 title: "How does software change?"
 category: "Software & Architecture Analytics Projects"
+short: ""
 keywords:
   - software engineering
   - empirical research

--- a/_sprojects/rastogi-2.md
+++ b/_sprojects/rastogi-2.md
@@ -1,6 +1,7 @@
 ---
 title: "Fairness in Software Engineering"
 category: "Software & Architecture Analytics Projects 2022-23"
+short: ""
 keywords:
   - software engineering
   - empirical research

--- a/_sprojects/rastogi-3.md
+++ b/_sprojects/rastogi-3.md
@@ -1,6 +1,7 @@
 ---
 title: "Missing Opportunities in Global Software Engineering"
 category: "Software & Architecture Analytics Projects 2022-23"
+short: ""
 keywords:
   - software engineering
   - empirical research

--- a/_sprojects/rastogi-4.md
+++ b/_sprojects/rastogi-4.md
@@ -1,6 +1,7 @@
 ---
 title: "Exploratory Study On Emerging Digital Technologies In SMEs"
 category: "Software & Architecture Analytics Projects 2022-23"
+short: ""
 keywords:
   - software engineering
   - empirical research

--- a/_sprojects/soliman-1.md
+++ b/_sprojects/soliman-1.md
@@ -1,6 +1,7 @@
 ---
 title: "Exploring Architectural Knowledge in Open Source Systems"
 category: "Software & Architecture Analytics Projects 2022-23"
+short: ""
 keywords:
   - Architectural Knowledge
   - Architectural Design Decisions
@@ -38,8 +39,7 @@ The steps could be adjusted based on the skills and interests of students.
 Contact: [Mohamed Soliman](m.a.m.soliman@rug.nl), or [Paris Avgeriou](p.avgeriou@rug.nl)
 
 # References
+
 - [1] L. Bass, P. Clements, and R. Kazman, Software Architecture in Practice, 2nd ed. Boston, MA, USA: Addison-Wesley Longman Publishing Co., Inc., 2003.
 - [2] A. Shahbazian, Y. Kyu Lee, D. Le, Y. Brun and N. Medvidovic, "Recovering Architectural Design Decisions," 2018 IEEE International Conference on Software Architecture (ICSA), Seattle, WA, 2018, pp. 95-9509.
 - [3] Xue ying Li, Peng Liang, and Tian qing Liu. Decisions and Their Making in OSS Development: An Exploratory Study Using the Hibernate Developer Mailing List. In Proceedings - Asia-Pacific Software Engineering Conference, APSEC, volume 2019-December, pages 323–330. IEEE Computer Society, 12 2019
-
-

--- a/_sprojects/storm-1.md
+++ b/_sprojects/storm-1.md
@@ -1,6 +1,7 @@
 ---
 title: "Domain-specific Spreadsheet Languages and Tools"
 category: "Language Engineering Projects"
+short: ""
 keywords:
   - language engineering
   - spreadsheets

--- a/_sprojects/storm-2.md
+++ b/_sprojects/storm-2.md
@@ -1,6 +1,7 @@
 ---
 title: "M3Solidity: M3 Source Code Model for Ethereum Solidity"
 category: "Software & Architecture Analytics Projects"
+short: ""
 keywords:
   - source code analysis
   - M3

--- a/_sprojects/storm-2.md
+++ b/_sprojects/storm-2.md
@@ -2,17 +2,17 @@
 title: "M3Solidity: M3 Source Code Model for Ethereum Solidity"
 category: "Software & Architecture Analytics Projects"
 keywords:
-- source code analysis
-- M3
-- Rascal
-- smart contracts
-  is_group: false
-  available: true
-  types:
-- BSc
-  posted: 2023-01-01
-  supervisors:
-- name: "Tijs van der Storm"
-  email: "storm@cwi.nl"
+  - source code analysis
+  - M3
+  - Rascal
+  - smart contracts
+is_group: false
+available: true
+types:
+  - BSc
+posted: 2023-01-01
+supervisors:
+  - name: "Tijs van der Storm"
+email: "storm@cwi.nl"
 ---
 Rascal is a language workbench and environment for source code analysis and transformation. One library component of Rascal is *M3* a general model to represent facts about source code. It includes information on files, classes, ASTs, name binding, type relations, containment, and optionally inheritance, call graphs etc. Currently, the model has been instantiated for Java, Javascript, and CSharp. The goal of this project is provide an M3 bridge to the Ethereum Solidity language. This will enable analysis and reverse engineering of Smart Contracts running on the Ethereum blockchain.

--- a/_sprojects/storm-3.md
+++ b/_sprojects/storm-3.md
@@ -1,6 +1,7 @@
 ---
 title: "Embedding Diagram Editors into Salix"
 category: "Language Engineering Projects"
+short: ""
 keywords:
   - language engineering
   - graphical modeling

--- a/_sprojects/storm-4.md
+++ b/_sprojects/storm-4.md
@@ -1,6 +1,7 @@
 ---
 title: "Hybrid Partial Evaluation for Javascript"
 category: "Language Engineering Projects"
+short: ""
 keywords:
   - language engineering
   - partial evaluation

--- a/_sprojects/storm-5.md
+++ b/_sprojects/storm-5.md
@@ -1,6 +1,7 @@
 ---
 title: "Extracting a Rascal Grammar From The Swift Reference Manual"
 category: "Language Engineering Projects"
+short: ""
 keywords:
   - language engineering
   - grammarware

--- a/_sprojects/storm-6.md
+++ b/_sprojects/storm-6.md
@@ -1,6 +1,7 @@
 ---
 title: "Implementing Nick Szabo's Contract Language"
 category: "Language Engineering Projects"
+short: ""
 keywords:
   - language engineering
   - block chain

--- a/_sprojects/storm-7.md
+++ b/_sprojects/storm-7.md
@@ -1,6 +1,7 @@
 ---
 title: "CodeBuff in Rascal"
 category: "Language Engineering Projects"
+short: ""
 keywords:
   - language engineering
   - pretty printing

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -76,6 +76,7 @@ $sub-footer-text-color: $white;
 @import "components/research-field";
 @import "components/icons";
 @import "components/team-card";
+@import "components/project-card";
 // @import "components/fonts"; // Uncomment this line to self host font
 
 // Pages


### PR DESCRIPTION
Implements US-M2. 

I have added a card component for student projects that shows basic information of the project. This includes keywords, types (MSc, BSc etc.), name, short description and project availability. 

These card components are layed out on the education page under a "student projects" heading, and uses the entries in the `sprojects` collection.

I also slightly modified the schema for the `sprojects` collection. I added a `short` field which should contain a short description about the project. I modified the existing files to conform to the schema and fixed invalid yaml formatting.

If there is no short description project cards will display a missing description message.