### PR TITLE
US-M1 News feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,7 @@ collections:
   - "team"
   - "projects"
   - "sprojects"
+  - "news"
 
 defaults:
   - scope:

--- a/_config.yml
+++ b/_config.yml
@@ -14,12 +14,25 @@ home:
   limit_services: 6
 
 collections:
-  - "team"
-  - "projects"
-  - "sprojects"
-  - "news"
+  team:
+    output: false
+  projects:
+    output: false
+  sprojects:
+    output: false
+  news:
+    output: true
 
 defaults:
+  - scope:
+      path: ""
+    values:
+      layout: "page"
+  - scope:
+      path: ""
+      type: "news"
+    values:
+      layout: "news-post"
   - scope:
       path: ""
       type: "team"

--- a/_data/menus.yml
+++ b/_data/menus.yml
@@ -8,9 +8,12 @@ main:
   - name: "Education"
     url: "/education/"
     weight: 4
+  - name: "News"
+    url: "/news/"
+    weight: 5
   - name: "Contact"
     url: "/contact/"
-    weight: 5
+    weight: 6
 
 footer:
   - name: "Home"

--- a/_includes/news-card.html
+++ b/_includes/news-card.html
@@ -1,0 +1,13 @@
+<a href="">
+  <div class="news-card">
+
+    <p>{{ post.date | date_to_long_string }}</p>
+    <h3 class="title">{{ post.title }}</h3>
+
+    <div class="keywords">
+      {% for keyword in post.keywords %}
+        <span>{{ keyword }}</span>
+      {% endfor %}
+    </div>
+  </div>
+</a>

--- a/_includes/news-card.html
+++ b/_includes/news-card.html
@@ -1,4 +1,4 @@
-<a href="">
+<a href="{{ post.url }}">
   <div class="news-card">
 
     <p>{{ post.date | date_to_long_string }}</p>

--- a/_layouts/news-post.html
+++ b/_layouts/news-post.html
@@ -1,0 +1,15 @@
+---
+layout: "default"
+---
+
+<div class="container pb-6 pt-6 pt-md-10 mt-2 pb-md-10 d-flex align-items-center flex-column">
+  <div style="max-width: 48rem;">
+    <h1 class="title">{{ page.title }}</h1>
+    <p>
+      <span>Posted on {{ page.date | date_to_long_string }}</span>
+    </p>
+    <div class="content">
+      {{ content }}
+    </div>
+  </div>
+</div>

--- a/_layouts/news-post.html
+++ b/_layouts/news-post.html
@@ -4,10 +4,19 @@ layout: "default"
 
 <div class="container pb-6 pt-6 pt-md-10 mt-2 pb-md-10 d-flex align-items-center flex-column">
   <div style="max-width: 48rem;">
-    <h1 class="title">{{ page.title }}</h1>
-    <p>
-      <span>Posted on {{ page.date | date_to_long_string }}</span>
-    </p>
+
+    <a href="/news">
+      <div class="d-flex align-items-center mb-2 mt-1 ">
+        <span>&#8592;</span>
+        <span>&nbsp;All news</span>
+      </div>
+    </a>
+
+    <div class="pb-3 pt-2">
+      <h1 class="title">{{ page.title }}</h1>
+      <p style="margin-top: -10px;">Posted on {{ page.date | date_to_long_string }}</p>
+    </div>
+
     <div class="content">
       {{ content }}
     </div>

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -9,7 +9,7 @@ bodyClass: "page-news"
     {{ content }}
   </div>
   <div class="d-flex news-feed justify-content-between mt-4">
-    <div class="d-flex flex-column news-post-dates fs-1 " style="gap: 5px;">
+    <div class="news-post-dates fs-1 " style="gap: 5px;">
       {% for post in site.news reversed %}
         <a href="{{ post.url }}">{{ post.date | date_to_long_string}}</a>
       {% endfor %}

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -5,7 +5,7 @@ bodyClass: "page-news"
 
 <div class="container pb-6 pt-6 pt-md-10 pb-md-10">
   <h1 class="title">{{page.title}}</h1>
-  <div class="content mt-4">
+  <div class="content">
     {{ content }}
   </div>
   <div class="d-flex news-feed justify-content-between mt-4">

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -1,0 +1,24 @@
+---
+layout: default
+bodyClass: "page-news"
+---
+
+<div class="container pb-6 pt-6 pt-md-10 pb-md-10">
+  <h1 class="title">{{page.title}}</h1>
+  <div class="content mt-4">
+    {{ content }}
+  </div>
+  <div class="d-flex news-feed justify-content-between mt-4">
+    <div class="d-flex flex-column news-post-dates fs-1 " style="gap: 5px;">
+      {% for post in site.news reversed %}
+        <a href="">{{ post.date | date_to_long_string}}</a>
+      {% endfor %}
+    </div>
+    <div class="d-flex flex-wrap news-post-cards" style="gap: 15px">
+      {% for post in site.news reversed %}
+        {% include news-card.html post=post %}
+      {% endfor %}
+    </div>
+  </div>
+</div>
+

--- a/_layouts/news.html
+++ b/_layouts/news.html
@@ -11,7 +11,7 @@ bodyClass: "page-news"
   <div class="d-flex news-feed justify-content-between mt-4">
     <div class="d-flex flex-column news-post-dates fs-1 " style="gap: 5px;">
       {% for post in site.news reversed %}
-        <a href="">{{ post.date | date_to_long_string}}</a>
+        <a href="{{ post.url }}">{{ post.date | date_to_long_string}}</a>
       {% endfor %}
     </div>
     <div class="d-flex flex-wrap news-post-cards" style="gap: 15px">

--- a/_news/2021-2022-student-projects.md
+++ b/_news/2021-2022-student-projects.md
@@ -1,0 +1,6 @@
+---
+title: "2021-2022 Student projects released"
+keywords:
+ - "Student Projects"
+date: 2021-09-05
+---

--- a/_news/daniel-feitosa-joins-search.md
+++ b/_news/daniel-feitosa-joins-search.md
@@ -4,3 +4,7 @@ keywords:
  - "member"
 date: 2014-01-01
 ---
+
+We are proud to annouce that Dr. Daniel Feitosa join the SEARCH group as an associate professor.
+Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+Recusandae dolores, possimus pariatur animi temporibus nesciunt praesentium.

--- a/_news/daniel-feitosa-joins-search.md
+++ b/_news/daniel-feitosa-joins-search.md
@@ -1,0 +1,6 @@
+---
+title: "Daniel Feitosa joins SEARCH group as associate professor."
+keywords:
+ - "member"
+date: 2014-01-01
+---

--- a/_news/project-funding.md
+++ b/_news/project-funding.md
@@ -1,0 +1,7 @@
+---
+title: "Project X has received funding from NWO"
+keywords:
+ - "funding"
+ - "project"
+date: 2022-02-12
+---

--- a/_news/turkey-charity.md
+++ b/_news/turkey-charity.md
@@ -6,6 +6,3 @@ keywords:
 date: 2023-02-05
 ---
 
-We are proud to annouce that Dr. Daniel Feitosa join the SEARCH group as an associate professor.
-Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-Recusandae dolores, possimus pariatur animi temporibus nesciunt praesentium.

--- a/_news/turkey-charity.md
+++ b/_news/turkey-charity.md
@@ -1,0 +1,11 @@
+---
+title: "SEARCH charity project for Turkey and Syria earthquake"
+keywords:
+ - "Charity"
+ - "Disaster"
+date: 2023-02-05
+---
+
+We are proud to annouce that Dr. Daniel Feitosa join the SEARCH group as an associate professor.
+Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+Recusandae dolores, possimus pariatur animi temporibus nesciunt praesentium.

--- a/_news/turkey-charity.md
+++ b/_news/turkey-charity.md
@@ -6,3 +6,15 @@ keywords:
 date: 2023-02-05
 ---
 
+One morning, when Gregor Samsa woke from troubled dreams, he found himself *transformed* in his bed into a horrible  [vermin](http://en.wikipedia.org/wiki/Vermin "Wikipedia Vermin"). He lay on his armour-like back, and if he lifted his head a little he could see his brown belly, slightly domed and divided by arches into stiff sections. The bedding was hardly able to cover **strong** it and seemed ready to slide off any moment. His many legs, pitifully thin compared with the size of the rest of him, link waved abouthelplessly as he looked. <cite>“What's happened to me?”</cite> he thought. It wasn't a dream. His room, a proper human room although a little too small, lay peacefully between its four familiar walls.
+
+## The bedding was hardly able to cover it
+
+It showed a lady fitted out with a fur hat and fur boa who sat upright, raising a heavy fur muff that covered the whole of her lower arm towards the viewer a solid fur muff into which her entire forearm disappeared..
+
+### Things we know about Gregor's sleeping habits
+
+- He always slept on his right side.
+- He has to get up early (to start another dreadful day).
+- He has a drawer and a alarm clock next to his bed.
+- His mother calls him when he gets up to late.

--- a/_sass/components/_news-card.scss
+++ b/_sass/components/_news-card.scss
@@ -1,0 +1,69 @@
+.news-card:hover {
+  transform: scale(1.0125) translateY(-5px);
+}
+
+.news-card {
+  display: flex;
+  flex-direction: column;
+
+  padding: 1.25rem 1.5rem;
+  box-shadow: rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0) 0px 0px 0px 0px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.1) 0px 4px 6px -4px;
+
+  // set border styles
+  border-style: solid;
+  border-width: 1px;
+  border-radius: 0.75rem;
+  border-color: #e5e7eb;
+  max-width: 24rem;
+  height: 100%;
+
+  // transition
+  transition: transform;
+  transition-duration: 100ms;
+  transition-timing-function: ease-out;
+
+  p {
+    margin: 0px;
+  }
+
+  .keywords {
+    margin-top: 0.5rem;
+
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: 5px;
+
+    span {
+      white-space: nowrap;
+      border-radius: 9999px;
+      padding-left: 0.625rem;
+      padding-right: 0.625rem;
+      font-size: 0.75rem;
+      line-height: 1rem;
+      padding-top: 0.125rem;
+      padding-bottom: 0.125rem;
+      background-color: rgb(254, 226, 226);
+      color: rgb(185, 28, 28);
+
+      /*  Enforce capitalized words since user defined keywords are inconsistent.
+          TODO: maybe remove this once CMS is in place? */
+      text-transform: capitalize;
+    }
+  }
+
+  // default font size for component
+  font-size: 1rem;
+  line-height: 1.5rem;
+  font-weight: 400;
+
+  background-color: white;
+  //background-color: #F3F4F6;
+
+  .title {
+    margin: 0px;
+    font-size: 1.25rem;
+    line-height: 1.75rem;
+    font-weight: 600;
+  }
+}

--- a/_sass/pages/_page-news.scss
+++ b/_sass/pages/_page-news.scss
@@ -1,0 +1,26 @@
+.news-post-cards {
+  max-width: 24rem;
+  width: 100%;
+}
+
+.news-post-dates {
+  flex-grow: 1;
+}
+
+@include media-breakpoint-up(lg) {
+  .news-post-cards {
+    max-width: 49rem;
+  }
+}
+
+// @include media-breakpoint-up(lg) {
+//   .news-post-cards {
+//     max-width: 64rem;
+//   }
+// }
+
+// @include media-breakpoint-up(xl) {
+//   .news-post-cards {
+//     max-width: 32rem;
+//   }
+// }

--- a/_sass/pages/_page-news.scss
+++ b/_sass/pages/_page-news.scss
@@ -4,7 +4,15 @@
 }
 
 .news-post-dates {
-  flex-grow: 1;
+  display: none;
+}
+
+@include media-breakpoint-up(md) {
+  .news-post-dates {
+    display: flex;
+    flex-grow: 1;
+    flex-direction: column;
+  }
 }
 
 @include media-breakpoint-up(lg) {

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -77,6 +77,7 @@ $sub-footer-text-color: $white;
 @import "components/icons";
 @import "components/team-card";
 @import "components/project-card";
+@import "components/news-card";
 // @import "components/fonts"; // Uncomment this line to self host font
 
 // Pages

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -83,6 +83,7 @@ $sub-footer-text-color: $white;
 @import "pages/page-home";
 @import "pages/page-teams";
 @import "pages/page-service";
+@import "pages/page-news";
 
 body {
   font-size: 16px;

--- a/news.md
+++ b/news.md
@@ -1,0 +1,12 @@
+---
+title: SEARCH News
+layout: news
+description: News feed from the SEARCH group.
+permalink: "/news/"
+intro_image: ""
+intro_image_absolute: false
+intro_image_hide_on_mobile: false
+---
+
+Lorem ipsum dolor sit amet, consectetur adipisicing elit.
+Recusandae dolores, possimus pariatur animi temporibus nesciunt praesentium.

--- a/news.md
+++ b/news.md
@@ -1,12 +1,12 @@
 ---
-title: SEARCH News
+title: SEARCH News Feed
 layout: news
-description: News feed from the SEARCH group.
+description: Here we regularly post updates about research project, new or departing team members, industry collaboration, released datasets, student projects and other general updates about the SEARCH group.
 permalink: "/news/"
 intro_image: ""
 intro_image_absolute: false
 intro_image_hide_on_mobile: false
 ---
 
-Lorem ipsum dolor sit amet, consectetur adipisicing elit.
-Recusandae dolores, possimus pariatur animi temporibus nesciunt praesentium.
+<!--TODO: get this description approved by team-->
+Here we regularly post updates about research project, new or departing team members, industry collaboration, released datasets, student projects and other general updates about the SEARCH group. We're also working on adding a RSS feed you can subscribe to for updates.


### PR DESCRIPTION
This PR implements US-M1. 

Specifically this change adds: 
 - a news-card component
 - a news feed page
 - some dummy news posts
 - generated pages for each news post 

News posts can be created in the `news` collection under the root level `_news` folder. The collection has three fields which are `title`, `keywords` and `date`. Keywords should be one two or three keywords describing what the update is about. The article content is written in markdown. 


**The news-card component** gives a quick overview of the article. It displays the three fields mentioned above, and links to the associated news post page. 

**The news feed page** gives an overview of the posted articles. In a sidebar, dates of posted articles listed out. The dates link to news posts, and are useful for quick navigation. For each news post there is also a news card in a grid, also linking to the associated post. The page has been added in menus under a `/news` URI. 

On **the generated news post** pages the markdown content of the post is rendered. The date is displayed and there is a link to navigate back to the news feed.  