### PR TITLE
US-M3: Research contributions

### DIFF
--- a/_data/contributions.json
+++ b/_data/contributions.json
@@ -1,0 +1,18 @@
+[
+    {
+        "title": "Dataset of Phabricator code reviews",
+        "link": "https://research.rug.nl/en/datasets/dataset-of-phabricator-code-reviews"
+    },
+    {
+        "title": "Dataset: Security vulnerabilities in open-source reused systems",
+        "link": "https://research.rug.nl/en/datasets/dataset-security-vulnerabilities-in-open-source-reused-systems"
+    },
+    {
+        "title": "Dataset: Investigating instability architectural smells evolution: an exploratory case study",
+        "link": "https://research.rug.nl/en/datasets/dataset-investigating-instability-architectural-smells-evolution-"
+    },
+    {
+        "title": "Dataset: Potential security vulnerabilities in open-source reused systems",
+        "link": "https://research.rug.nl/en/datasets/dataset-potential-security-vulnerabilities-in-open-source-reused-"
+    }
+]

--- a/_layouts/research.html
+++ b/_layouts/research.html
@@ -6,9 +6,23 @@ bodyClass: "page-research"
 
 <div class="container mx-auto px-4 pb-6 pt-[100px] pb-md-10">
   <h1 class="text-black text-5xl leading-5 lg:text-[50px] font-semibold mb-8">{{page.title}}</h1>
+
+  <section>
+    <h3 class="text-2xl">Contributions</h3>
+
+    <ul class="list-disc ml-4">
+      {% for contrib in site.data.contributions %}
+        <li>
+          <a class="underline hover:text-gray-500" href="{{contrib.link}}">
+            {{contrib.title}}
+          </a>
+        </li>
+      {% endfor %}
+    </ul>
+  </section>
+
   <section class="space-y-8">
     <h2 class="text-2xl">Research Projects</h2>
-
     <div class="grid lg:grid-cols-2 gap-4">
       {% for project in site.projects %}
         <a href="{{ project.url }}">

--- a/_layouts/research.html
+++ b/_layouts/research.html
@@ -4,6 +4,7 @@ layout: default
 bodyClass: "page-research"
 # entries in `sections` match the text of a heading on the page
 sections:
+ - Contributions
  - Active Projects
  - Past Projects
 ---

--- a/contributions.py
+++ b/contributions.py
@@ -1,0 +1,52 @@
+import urllib.request
+import json
+from urllib import response
+from xml.etree import ElementTree as ET
+import logging
+import sys
+
+
+class Contribution:
+  """Represents a contribution loaded from the RSS feed."""
+  def __init__(self, title, link):
+    self.title = title
+    self.link = link
+
+  def to_dict(self):
+    return {
+      'title': self.title,
+      'link': self.link,
+    }
+
+
+class RSSContributionScraper():
+  def __init__(self, rss_link):
+    self.rss_link = rss_link
+
+  def get_contributions(self):
+    """Extracts RSS contibution entries from RSS feed."""
+    response = urllib.request.urlopen(self.rss_link)
+    rss_doc = ET.fromstring(response.read())
+    channels = rss_doc.findall("channel")
+    return [Contribution(item[0].text, item[1].text) for item in channels[0] if item.tag == "item"]
+
+
+def contributions_to_json(contributions, pretty=False):
+  """Convert a list of contributions to JSON."""
+  indents = 4 if pretty else None
+  return json.dumps([contrib.to_dict() for contrib in contributions], indent=indents)
+
+
+def main():
+  filepath = '_data/contributions.json'
+  rss_link = "https://research.rug.nl/en/organisations/software-engineering/datasets/?format=rss"
+
+  scraper = RSSContributionScraper(rss_link)
+  contribs = scraper.get_contributions()
+
+  # write file
+  with open(filepath, "w") as file:
+    file.write(contributions_to_json(contribs, pretty=True))
+
+if __name__ == "__main__":
+  main()


### PR DESCRIPTION
This PR implements US-M3. 

A section simple list overview of contributions has been added. The title of the contributions is displayed and each entry links to the relevant page on `research.rug.nl`.

A python script for scraping contributions from the RSS feed on `research.rug.nl` has been added. It uses no external dependencies and can be ran with `python3 contributions.py` from the top level directory of the project. The script has a hardcoded link to the datasets RSS feed of the SEARCH group. 

The scripts stores the output in the `_data` directory in the project root. 