### PR TITLE
Deployment Specific Functionality

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -4,7 +4,7 @@ backend:
   repo: search-rug/search-rug.github.io
   branch: main
   # TODO: Initalize CMS in js so enviromnent variables can be used.
-  # Also change `CMS_URL` in admin/index.html changeing urls below.
+  # Also change `CMS_URL` in admin/index.html when changeing urls below.
   identity_url: "https://search-rug.netlify.app/.netlify/identity"
   gateway_url: "https://search-rug.netlify.app/.netlify/git"
   site_domain: "https://search-rug.netlify.app"

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -3,6 +3,8 @@ backend:
   name: git-gateway
   repo: search-rug/search-rug.github.io
   branch: main
+  # TODO: Initalize CMS in js so enviromnent variables can be used.
+  # Also change `CMS_URL` in admin/index.html changeing urls below.
   identity_url: "https://search-rug.netlify.app/.netlify/identity"
   gateway_url: "https://search-rug.netlify.app/.netlify/git"
   site_domain: "https://search-rug.netlify.app"

--- a/admin/index.html
+++ b/admin/index.html
@@ -9,6 +9,15 @@
     <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
   </head>
   <body>
+    <script>
+      // TODO: Define when and where to redirect, in a central place.
+      const CMS_URL = "https://search-rug.netlify.app"
+      const current_hostname = new URL(window.location.href).hostname
+      const desired_hostname = new URL(CMS_URL).hostname
+      if (!current_hostname.includes(desired_hostname)) {
+        window.location.href = CMS_URL
+      }
+    </script>
     <!-- Include the script that builds the page and powers Netlify CMS -->
     <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
   </body>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,9 @@
+# This file configures how the search-rug website is deployed to Netlify.
+# We define a build command so jekyll to only use the /admin dir as source.
+# This ensures that only the CMS will be rendered on the Netlify deployment.
+
 [build]
-  command = "jekyll build"
+  command = "jekyll build --source admin"
   publish = "_site"
 
 [build.environment]


### PR DESCRIPTION
This PR ensures two things: 
 - only the CMS is rendered on Netlify
 - on GitHub Pages the `/admin` page redirects to the CMS