### PR TITLE
Research Contribution Cards

### DIFF
--- a/_includes/research-contribution-card.html
+++ b/_includes/research-contribution-card.html
@@ -4,6 +4,7 @@
     title: string
     description?: string
     download_count: int
+    url: string
 -->
 
 <article class="rounded-lg border shadow-sm h-full">

--- a/_includes/research-contribution-card.html
+++ b/_includes/research-contribution-card.html
@@ -1,0 +1,24 @@
+<!--
+  Expects a list of objects in the `contributions` include variable.
+  Objects have following fields where ? marks an optional field:
+    title: string
+    description?: string
+    download_count: int
+-->
+
+<article class="rounded-lg border shadow-sm h-full">
+  <div class="flex gap-6 w-full items-center h-full p-10 py-8">
+    <div class="flex-grow space-y-2">
+      <a href="{{ include.contribution.url }}" class="underline text-2xl hover:text-gray-500">{{ include.contribution.title  }}</a>
+      {% if include.contribution.description %}
+        <p class="text-sm">{{ include.contribution.description }}</p>
+      {% endif %}
+    </div>
+    {% if include.contribution.download_count %}
+      <div class="flex flex-col items-center">
+        <p class="text-2xl font-semibold">{{ include.contribution.download_count }}</p>
+        <p class="text-sm text-gray-500">Downloads</p>
+      </div>
+    {% endif %}
+  </div>
+</article>

--- a/_layouts/research.html
+++ b/_layouts/research.html
@@ -16,6 +16,20 @@ sections:
   <!-- Adds a scroll button for each section defined above. -->
   {% include section-scroll-buttons.html sections=layout.sections %}
 
+  <section class="space-y-3">
+    {% assign active_projects = site.projects | where: "archived", "false" %}
+    <h2 class="text-2xl">Active Projects</h2>
+    {% include project-card-grid.html projects=active_projects card_component="research-project-card.html" %}
+  </section>
+
+  {% assign past_projects = site.projects | where: "archived", "true" %}
+  {% if past_projects.size > 0 %}
+    <section class="space-y-2">
+      <h2 class="text-2xl">Past Projects</h2>
+      {% include page-list.html pages=past_projects %}
+    </section>
+  {% endif %}
+
   <section class="space-y-2">
     <h3 class="text-2xl">Publications</h3>
     <div class="grid xl:grid-cols-2 gap-4">
@@ -33,18 +47,4 @@ sections:
       {% endfor %}
     </div>
   </section>
-
-  <section class="space-y-3">
-    {% assign active_projects = site.projects | where: "archived", "false" %}
-    <h2 class="text-2xl">Active Projects</h2>
-    {% include project-card-grid.html projects=active_projects card_component="research-project-card.html" %}
-  </section>
-
-  {% assign past_projects = site.projects | where: "archived", "true" %}
-  {% if past_projects.size > 0 %}
-    <section class="space-y-2">
-      <h2 class="text-2xl">Past Projects</h2>
-      {% include page-list.html pages=past_projects %}
-    </section>
-  {% endif %}
 </div>

--- a/_layouts/research.html
+++ b/_layouts/research.html
@@ -10,7 +10,7 @@ sections:
  - Past Projects
 ---
 
-<div class="container space-y-8 mx-auto px-4 pb-6 pt-[100px] pb-md-10">
+<div class="container space-y-12 mx-auto px-4 pb-6 pt-[100px] pb-md-10">
   <h1 class="text-black text-5xl leading-5 lg:text-[50px] font-semibold mb-8">{{page.title}}</h1>
 
   <!-- Adds a scroll button for each section defined above. -->

--- a/_layouts/research.html
+++ b/_layouts/research.html
@@ -4,10 +4,10 @@ layout: default
 bodyClass: "page-research"
 # entries in `sections` match the text of a heading on the page
 sections:
- - Publications
- - Datasets
- - Active Projects
- - Past Projects
+  - Active Projects
+  - Past Projects
+  - Publications
+  - Datasets
 ---
 
 <div class="container space-y-12 mx-auto px-4 pb-6 pt-[100px] pb-md-10">

--- a/_layouts/research.html
+++ b/_layouts/research.html
@@ -16,14 +16,22 @@ sections:
   <!-- Adds a scroll button for each section defined above. -->
   {% include section-scroll-buttons.html sections=layout.sections %}
 
-  <section>
+  <section class="space-y-2">
     <h3 class="text-2xl">Publications</h3>
-    {% include page-list.html pages=site.data.publications %}
+    <div class="grid xl:grid-cols-2 gap-4">
+      {% for publication in site.data.publications %}
+        {% include research-contribution-card.html contribution=publication %}
+      {% endfor %}
+    </div>
   </section>
 
-  <section>
+  <section class="space-y-2">
     <h3 class="text-2xl">Datasets</h3>
-    {% include page-list.html pages=site.data.datasets %}
+    <div class="grid xl:grid-cols-2 gap-4">
+      {% for dataset in site.data.datasets %}
+        {% include research-contribution-card.html contribution=dataset %}
+      {% endfor %}
+    </div>
   </section>
 
   <section class="space-y-3">


### PR DESCRIPTION
This PR adds cards for research contributions for datasets and publications. 

The cards require a `title` and `url` to be specified, and optionally a `description` and `download_count` can also be set. Clicking the title of the card takes the user to the specified `url`. Since the card is designed to link to an external page rather than a internal page it has a different styling than the website's project cards.

<img width="1283" alt="Screenshot 2023-04-25 at 14 31 34" src="https://user-images.githubusercontent.com/49387825/234281249-6168a36e-33a2-426d-a09c-612865135e99.png">

> Example of research contribution cards with varying degrees of optional fields set. 
