### PR TITLE
[Refactor]: Use email as relation values

### DIFF
--- a/_courses/WBCS005-05-ayushi.md
+++ b/_courses/WBCS005-05-ayushi.md
@@ -1,26 +1,26 @@
 ---
 code: WBCS005-05
+coordinators: null
+external_coordinators:
+- email: m.h.f.wilkinson@rug.nl
+  name: M.H.F. Wilkinson
+external_lecturers:
+- email: m.h.f.wilkinson@rug.nl
+  name: M.H.F. Wilkinson
+- email: d.dustegor@rug.nl
+  name: D. Düstegör
+- email: m.riveni@rug.nl
+  name: M. Riveni PhD
+- email: s.d.frey@rug.nl
+  name: S.D. Frey
+- email: cara.tursun@rug.nl
+  name: O.T. Tursun
+- email: f.f.m.mohsen@rug.nl
+  name: F.F.M. Mohsen
+- email: a.shahbahrami@rug.nl
+  name: A. Shahbahrami
+lecturers:
+- a.rastogi@rug.nl
 name: Introduction to Computing Science
 ocasys: https://ocasys.rug.nl/current/catalog/course/WBCS005-05
-coordinators:
-external_coordinators:
-  - name: "M.H.F. Wilkinson"
-    email: "m.h.f.wilkinson@rug.nl"
-lecturers:
-  - Dr. Ayushi Rastogi
-external_lecturers:
-  - name: "M.H.F. Wilkinson"
-    email: "m.h.f.wilkinson@rug.nl"
-  - name: "D. Düstegör"
-    email: "d.dustegor@rug.nl"
-  - name: "M. Riveni PhD"
-    email: "m.riveni@rug.nl"
-  - name: "S.D. Frey"
-    email: "s.d.frey@rug.nl"
-  - name: "O.T. Tursun"
-    email: "cara.tursun@rug.nl"
-  - name: "F.F.M. Mohsen"
-    email: "f.f.m.mohsen@rug.nl"
-  - name: "A. Shahbahrami"
-    email: "a.shahbahrami@rug.nl"
 ---

--- a/_courses/WBCS008-05-vasilios.md
+++ b/_courses/WBCS008-05-vasilios.md
@@ -1,12 +1,12 @@
 ---
 code: WBCS008-05
+coordinator:
+  email: v.andrikopoulos@rug.nl
+  name: Vasilios Andrikopoulos
+coordinators:
+- v.andrikopoulos@rug.nl
+lecturers:
+- v.andrikopoulos@rug.nl
 name: In-company or Research Internship (CS)
 ocasys: https://ocasys.rug.nl/current/catalog/course/WBCS008-05
-coordinator:
-  name: Vasilios Andrikopoulos
-  email: v.andrikopoulos@rug.nl
-coordinators:
-  - Prof. Dr. Vasilios Andrikopoulos
-lecturers:
-  - Prof. Dr. Vasilios Andrikopoulos
 ---

--- a/_courses/WBCS017-10-andrea.md
+++ b/_courses/WBCS017-10-andrea.md
@@ -1,10 +1,10 @@
 ---
 code: WBCS017-10
+coordinators:
+- a.capiluppi@rug.nl
+lecturers:
+- a.capiluppi@rug.nl
+- paris@cs.rug.nl
 name: Software Engineering
 ocasys: https://ocasys.rug.nl/current/catalog/course/WBCS017-10
-coordinators:
-  - Prof. Dr. Andrea Capiluppi
-lecturers:
-  - Prof. Dr. Andrea Capiluppi
-  - Prof. dr. ir. Paris Avgeriou
 ---

--- a/_courses/WBCS028-05-soliman.md
+++ b/_courses/WBCS028-05-soliman.md
@@ -1,10 +1,10 @@
 ---
 code: WBCS028-05
+coordinators:
+- m.a.m.soliman@rug.nl
+lecturers:
+- m.a.m.soliman@rug.nl
+- d.feitosa@rug.nl
 name: Object-Oriented Programming (for CS)
 ocasys: https://ocasys.rug.nl/current/catalog/course/WBCS028-05
-coordinators:
-  - Dr. Mohamed A.M. Soliman
-lecturers:
-  - Dr. Mohamed A.M. Soliman
-  - Dr. Daniel Feitosa
 ---

--- a/_courses/WBCS901-15-paris.md
+++ b/_courses/WBCS901-15-paris.md
@@ -1,12 +1,12 @@
 ---
 code: WBCS901-15
+coordinators:
+- paris@cs.rug.nl
+external_lecturers:
+- email: g.azzopardi@rug.nl
+  name: dr G. Azzopardi
+lecturers:
+- paris@cs.rug.nl
 name: Bachelor's project
 ocasys: https://ocasys.rug.nl/current/catalog/course/WBCS901-15
-coordinators:
-  - Prof. dr. ir. Paris Avgeriou
-lecturers:
-  - Prof. dr. ir. Paris Avgeriou
-external_lecturers:
-  - name: "dr G. Azzopardi"
-    email: "g.azzopardi@rug.nl"
 ---

--- a/_courses/WMCS004-05-paris.md
+++ b/_courses/WMCS004-05-paris.md
@@ -1,10 +1,10 @@
 ---
 code: WMCS004-05
+coordinators:
+- paris@cs.rug.nl
+lecturers:
+- paris@cs.rug.nl
+- d.feitosa@rug.nl
 name: Software Architecture
 ocasys: https://ocasys.rug.nl/current/catalog/course/WMCS004-05
-coordinators:
-  - Prof. dr. ir. Paris Avgeriou
-lecturers:
-  - Prof. dr. ir. Paris Avgeriou
-  - Dr. Daniel Feitosa
 ---

--- a/_courses/WMCS005-05-vasilios.md
+++ b/_courses/WMCS005-05-vasilios.md
@@ -1,12 +1,12 @@
 ---
 code: WMCS005-05
+coordinators:
+- v.andrikopoulos@rug.nl
+external_lecturers:
+- email: a.lazovik@rug.nl
+  name: Alexander Lazovik
+lecturers:
+- v.andrikopoulos@rug.nl
 name: Web and Cloud Computing
 ocasys: https://ocasys.rug.nl/current/catalog/course/WMCS005-05
-coordinators:
-  - Prof. Dr. Vasilios Andrikopoulos
-lecturers:
-  - Prof. Dr. Vasilios Andrikopoulos
-external_lecturers:
-  - name: "Alexander Lazovik"
-    email: "a.lazovik@rug.nl"
 ---

--- a/_courses/WMCS013-05-andrea.md
+++ b/_courses/WMCS013-05-andrea.md
@@ -1,9 +1,9 @@
 ---
 code: WMCS013-05
+coordinators:
+- a.capiluppi@rug.nl
+lecturers:
+- a.capiluppi@rug.nl
 name: Software Maintenance and Evolution
 ocasys: https://ocasys.rug.nl/current/catalog/course/WMCS013-05
-coordinators:
-  - Prof. Dr. Andrea Capiluppi
-lecturers:
-  - Prof. Dr. Andrea Capiluppi
 ---

--- a/_courses/WMCS014-05-paris.md
+++ b/_courses/WMCS014-05-paris.md
@@ -1,10 +1,10 @@
 ---
 code: WMCS014-05
+coordinators:
+- paris@cs.rug.nl
+lecturers:
+- paris@cs.rug.nl
+- m.a.m.soliman@rug.nl
 name: Evidence-Based Software Engineering
 ocasys: https://ocasys.rug.nl/current/catalog/course/WMCS014-05
-coordinators:
-  - Prof. dr. ir. Paris Avgeriou
-lecturers:
-  - Prof. dr. ir. Paris Avgeriou
-  - Dr. Mohamed A.M. Soliman
 ---

--- a/_courses/WMCS031-05-ayushi.md
+++ b/_courses/WMCS031-05-ayushi.md
@@ -1,9 +1,9 @@
 ---
 code: WMCS031-05
+coordinators:
+- a.rastogi@rug.nl
+lecturers:
+- a.rastogi@rug.nl
 name: Software Analytics
 ocasys: https://ocasys.rug.nl/current/catalog/course/WMCS031-05
-coordinators:
-  - Dr. Ayushi Rastogi
-lecturers:
-  - Dr. Ayushi Rastogi
 ---

--- a/_includes/research-project-card.html
+++ b/_includes/research-project-card.html
@@ -16,8 +16,8 @@
       <div class="flex flex-col">
         <p class="text-sm">Members</p>
         <p class="font-medium flex -space-x-2">
-          {% for member_name in project.members %}
-            {% assign member = site.team | where: "title", member_name | first %}
+          {% for member_email in project.members %}
+            {% assign member = site.team | where_exp: "m", "m.contact.email == member_email" | first %}
             {% include member-pfp-circle.html member=member %}
           {% endfor %}
         </p>

--- a/_layouts/education-project.html
+++ b/_layouts/education-project.html
@@ -12,8 +12,8 @@ backlink:
 <section>
   <h2 class="text-xl my-2">Contact</h3>
   <div class="grid md:grid-cols-2 gap-4">
-    {% for member_name in page.supervisors %}
-      {% assign member = site.team | where: "title", member_name | first %}
+    {% for member_email in page.supervisors %}
+    {% assign member = site.team | where_exp: "m", "m.contact.email == member_email" | first %}
       {% include team-card-compact.html member=member %}
     {% endfor %}
   </div>

--- a/_layouts/research-project.html
+++ b/_layouts/research-project.html
@@ -12,8 +12,8 @@ backlink:
 <section>
   <h2 class="text-xl my-2">Contact</h3>
   <div class="grid md:grid-cols-2 gap-4">
-    {% for member_name in page.members %}
-      {% assign member = site.team | where: "title", member_name | first %}
+    {% for member_email in page.members %}
+      {% assign member = site.team | where_exp: "m", "m.contact.email == member_email" | first %}
       {% include team-card-compact.html member=member %}
     {% endfor %}
   </div>

--- a/_projects/1-yikun-visdom.md
+++ b/_projects/1-yikun-visdom.md
@@ -1,18 +1,21 @@
 ---
-title: "VISDOM - Visual diagnosis for DevOps software development"
-status: "In Progress"
 archived: false
-members:
-  - Prof. dr. ir. Paris Avgeriou
-  - Dr. Mohamed A.M. Soliman
-  - Yikun Li
-short: "The VISDOM project will develop new types of visualization that utilize and merge data from several data sources in modern DevOps development. The aim is to provide simple “health check” visualizations about the state of the development process, software and use."
-homepage: "https://iteavisdom.org/"
-logo: "images/projects/visdom-logo.png"
 funding:
-  - agency: "ITEA3/RVO"
-    shortname: "ITEA3/RVO"
-    number: "17038"
+- agency: ITEA3/RVO
+  number: '17038'
+  shortname: ITEA3/RVO
+homepage: https://iteavisdom.org/
+logo: images/projects/visdom-logo.png
+members:
+- paris@cs.rug.nl
+- m.a.m.soliman@rug.nl
+- yikun.li@rug.nl
+short: The VISDOM project will develop new types of visualization that utilize and
+  merge data from several data sources in modern DevOps development. The aim is to
+  provide simple “health check” visualizations about the state of the development
+  process, software and use.
+status: In Progress
+title: VISDOM - Visual diagnosis for DevOps software development
 ---
 
 Visualization is a powerful communication method, especially in cross-disciplinary communication with various stakeholders, as in operations. Many software development tools already provide some visualizations, but integrated views that combine data from several sources are still at the research prototype level.

--- a/_projects/2-sahar-suscloud.md
+++ b/_projects/2-sahar-suscloud.md
@@ -1,15 +1,19 @@
 ---
-title: "Sustainable Cloud"
-status: "In Progress"
 archived: false
-members:
-  - "Prof. Dr. Vasilios Andrikopoulos"
-  - "Sahar Ahmadisakha"
-short: "This project aims to develop a sustainability-aware architecting framework specifically for cloud-based software services which incorporates all dimensions of system sustainability. The framework is structured around the use of sustainability indicators, one per dimension, as the means of abstracting away from dimension-specific concerns."
 funding:
-  - agency: "NWO"
-    shortname: "NWO"
-    number: "OCENW.M20.243"
-
+- agency: NWO
+  number: OCENW.M20.243
+  shortname: NWO
+members:
+- v.andrikopoulos@rug.nl
+- s.ahmadisakha@rug.nl
+short: This project aims to develop a sustainability-aware architecting framework
+  specifically for cloud-based software services which incorporates all dimensions
+  of system sustainability. The framework is structured around the use of sustainability
+  indicators, one per dimension, as the means of abstracting away from dimension-specific
+  concerns.
+status: In Progress
+title: Sustainable Cloud
 ---
+
 The ever-increasing digitalization of our world exacerbated the need (and opportunity) to address global sustainability goals at the software level. In fact, architecting sustainable software-intensive systems is recognized as one of the grand challenges of contemporary software engineering. The ubiquity of such systems provides a unique opportunity for a singular point of intervention in ameliorating sustainability across the socio-technical spectrum. At the same time, it also generates the necessary urgency in delivering sustainability through appropriate architecting practices. These practices are particularly compelling because they allow us to reason and evaluate system sustainability throughout the system's lifecycle. The wide adoption of cloud computing, however, where software, platforms, and infrastructure are delivered as-a-service makes this task complicated due to the opaqueness of consumed services. Related work on the topic so far has focused mainly on minimizing energy consumption at the data center level, i.e. on the environmental dimension, at the expense of the other sustainability dimensions, that is the technical, economic, and social ones. To address this deficiency, this project aims to develop a sustainability-aware architecting framework specifically for cloud-based software services which incorporates all dimensions of system sustainability. The framework is structured around the use of sustainability indicators, one per dimension, as the means of abstracting away from dimension-specific concerns. A major component of this project is the definition and evaluation of appropriate metrics associated with each indicator. Beyond that, our position, which we aim to test through this project, is that improving the indicator for each of the sustainability dimensions creates a positive reinforcement effect on the other indicators. We aim to investigate the efficacy of this (pro)position through a combination of empirical software engineering and design science. To achieve this goal, we will also create solid architecting tools, methods, and guidelines for delivering sustainability-aware cloud-based software services. By these means, SustainableCloud will actively contribute to developing a sustainability-aware future cloud

--- a/_projects/3-ruiyin-architecture-erosion.md
+++ b/_projects/3-ruiyin-architecture-erosion.md
@@ -1,12 +1,15 @@
 ---
-title: "Understanding and Alerting Architecture Erosion during Software Development"
-status: "In Progress"
 archived: false
+logo: null
 members:
-  - "Prof. dr. ir. Paris Avgeriou"
-  - "Ruiyin Li"
-short: "This research project aims to increase understanding of architecture erosion and provide strategies for mitigating its effects. Our objective is to assist researchers and practitioners in detecting and mitigating architecture erosion, with the aim of (partially) resolving this issue."
-logo:
+- paris@cs.rug.nl
+- r.li@rug.nl
+short: This research project aims to increase understanding of architecture erosion
+  and provide strategies for mitigating its effects. Our objective is to assist researchers
+  and practitioners in detecting and mitigating architecture erosion, with the aim
+  of (partially) resolving this issue.
+status: In Progress
+title: Understanding and Alerting Architecture Erosion during Software Development
 ---
 
 Architecture in software systems may experience degradation over time as a result of accumulated changes. As the system evolves, the accumulation of such problems (e.g., architectural violations) can cause the implemented architecture to deviate away from the intended architecture. The phenomenon of divergence between the intended and implemented architectures is regarded as architecture erosion. An eroded architecture can aggravate the brittleness of the system and decrease architecture sustainability. For instance, a software system with an eroded architecture may lead to the deterioration of the engineering quality of the system and make it challenging for developers to comprehend the internal structure of the system. This research project aims to increase understanding of architecture erosion and provide strategies for mitigating its effects. Our objective is to assist researchers and practitioners in detecting and mitigating architecture erosion, with the aim of (partially) resolving this issue.

--- a/_projects/4-cezar-classification.md
+++ b/_projects/4-cezar-classification.md
@@ -1,9 +1,12 @@
 ---
-title: "Detecting Similarities between Software Systems Based on NLP Techniques"
-status: "In Progress"
 archived: false
 members:
-  - "Prof. Dr. Andrea Capiluppi"
-  - "Cezar Sas"
-short: "This project aims to form clusters of similarly scoped software systems, based on an NLP-informed taxonomy. This is similar to a biological classification, where different species (i.e., software systems) might share very few similarities, but they might belong to the same family (i.e., application domain)"
+- a.capiluppi@rug.nl
+- c.a.sas@rug.nl
+short: This project aims to form clusters of similarly scoped software systems, based
+  on an NLP-informed taxonomy. This is similar to a biological classification, where
+  different species (i.e., software systems) might share very few similarities, but
+  they might belong to the same family (i.e., application domain)
+status: In Progress
+title: Detecting Similarities between Software Systems Based on NLP Techniques
 ---

--- a/_projects/5-sutoyo-nlp-td.md
+++ b/_projects/5-sutoyo-nlp-td.md
@@ -1,15 +1,19 @@
 ---
-title: "The Impact of Natural Language Processing Approach on the Detection of Technical Debt"
-status: "In Progress"
 archived: false
-members:
-  - "Prof. Dr. Andrea Capiluppi"
-  - "Edi Sutoyo"
-short: "This project aims to increase the accuracy of automatic classification and, through it, eliminate a significant portion of the costs relating to technical debt detection."
 funding:
-  - agency: "Center for Education Financial Services, Ministry of Education, Culture, Research, and Technology, the Republic of Indonesia"
-    shortname: "Kemendikbudristek" # TODO: what would be an appropriate shortname for this?
-    number: "1036/J5.2.3/BPI.LG/VIII/2022"
+- agency: Center for Education Financial Services, Ministry of Education, Culture,
+    Research, and Technology, the Republic of Indonesia
+  number: 1036/J5.2.3/BPI.LG/VIII/2022
+  shortname: Kemendikbudristek
+members:
+- a.capiluppi@rug.nl
+- e.sutoyo@rug.nl
+short: This project aims to increase the accuracy of automatic classification and,
+  through it, eliminate a significant portion of the costs relating to technical debt
+  detection.
+status: In Progress
+title: The Impact of Natural Language Processing Approach on the Detection of Technical
+  Debt
 ---
 
 Technical debt (TD) is an economic term used to depict non-optimal choices made in the software development process. It occurs usually when developers take shortcuts instead of following agreed-upon development practices, and unchecked growth of technical debt can start to incur negative effects on software development processes. Technical debt detection and management are mainly done manually, and this is both a slow and costly way of detecting technical debt. Automatic detection would solve this issue, but even state-of-the-art tools of today do not accurately detect the appearance of technical debt. Therefore, increasing the accuracy of automatic classification is of high importance, so that we could eliminate a significant portion of the costs relating to technical debt detection.

--- a/_sprojects/andrikopoulos-1.md
+++ b/_sprojects/andrikopoulos-1.md
@@ -1,22 +1,24 @@
 ---
-title: "Mining cloud cost-awareness from open-source repositories"
-category: "Software & Architecture Analytics Projects"
 archived: false
-short: "We are offering a series of projects under the umbrella of mining cloud cost awareness, that is, of software developers being aware of the costs of deploying and operating cloud-based software."
-keywords:
-  - Cloud Computing
-  - Mining Software Repositories
-  - Cost
-is_group: false
 available: true
-types:
-  - BSc
-  - MSc Int
-  - MSc
+category: Software & Architecture Analytics Projects
+is_group: false
+keywords:
+- Cloud Computing
+- Mining Software Repositories
+- Cost
 posted: 2023-02-10
+short: We are offering a series of projects under the umbrella of mining cloud cost
+  awareness, that is, of software developers being aware of the costs of deploying
+  and operating cloud-based software.
 supervisors:
-  - Prof. Dr. Vasilios Andrikopoulos
-  - Dr. Daniel Feitosa
+- v.andrikopoulos@rug.nl
+- d.feitosa@rug.nl
+title: Mining cloud cost-awareness from open-source repositories
+types:
+- BSc
+- MSc Int
+- MSc
 ---
 
 We are offering a series of projects under the umbrella of mining cloud cost awareness, that is, of software developers being aware of the costs of deploying and operating cloud-based software, and taking actions to address them. The projects are based on the Mining Software Repositories approach, and use publicly available repositories on GitHub. The projects under this topic build on the results of the [collaborative thesis project](https://fse.studenttheses.ub.rug.nl/27946/) by Berardi, Penca, and Boza.

--- a/_sprojects/andrikopoulos-2.md
+++ b/_sprojects/andrikopoulos-2.md
@@ -1,20 +1,24 @@
 ---
-title: "A Survey of Cloud Cost Calculators"
-category: "Software & Architecture Analytics Projects"
 archived: false
-short: "This project aims to survey existing approaches from both research (through e.g. a literature review) and practice (by means of locating and examining open source cost calculator projects) in order to compare and contrast these approaches, forming the State of the Art on the topic."
-keywords:
-  - Cloud Computing
-  - Cost
-is_group: false
 available: true
-types:
-  - BSc
-  - MSc Int
+category: Software & Architecture Analytics Projects
+is_group: false
+keywords:
+- Cloud Computing
+- Cost
 posted: 2023-02-10
+short: This project aims to survey existing approaches from both research (through
+  e.g. a literature review) and practice (by means of locating and examining open
+  source cost calculator projects) in order to compare and contrast these approaches,
+  forming the State of the Art on the topic.
 supervisors:
-  - Prof. Dr. Vasilios Andrikopoulos
+- v.andrikopoulos@rug.nl
+title: A Survey of Cloud Cost Calculators
+types:
+- BSc
+- MSc Int
 ---
+
 The utility computing-oriented billing of cloud services means that users of these services get charged over time and intensity of use in a similar manner to public utilities such as electricity or phones. As a result, both researchers and practitioners have become interested on developing tools calculating the cost of their software on cloud services before they are even actually deployed and ran there. This project aims to survey existing approaches from both research (through e.g. a literature review) and practice (by means of locating and examining open source cost calculator projects) in order to compare and contrast these approaches, forming the State of the Art on the topic.
 
 ### Literature

--- a/_sprojects/andrikopoulos-3.md
+++ b/_sprojects/andrikopoulos-3.md
@@ -1,20 +1,21 @@
 ---
-title: "Establishing the environmental footprint of chatbots"
-category: "Software & Architecture Analytics Projects 2022-23"
 archived: false
-short: "This project aims to investigate what is the environmental footprint of training and using chatbots."
-keywords:
-  - Cloud Computing
-  - Sustainability
-  - Energy Monitoring
-  - Chatbots
-is_group: false
 available: true
-types:
-  - MSc
+category: Software & Architecture Analytics Projects 2022-23
+is_group: false
+keywords:
+- Cloud Computing
+- Sustainability
+- Energy Monitoring
+- Chatbots
 posted: 2023-02-10
+short: This project aims to investigate what is the environmental footprint of training
+  and using chatbots.
 supervisors:
-  - Prof. Dr. Vasilios Andrikopoulos
+- v.andrikopoulos@rug.nl
+title: Establishing the environmental footprint of chatbots
+types:
+- MSc
 ---
 
 This project aims to investigate what is the environmental footprint of training and using chatbots. For this purpose, an open source chatbot will be used as a reference, its energy consumption on a reference machine will be established for both training and use, and the results will be used for establishing a benchmark.

--- a/_sprojects/avgeriou-soliman-1.md
+++ b/_sprojects/avgeriou-soliman-1.md
@@ -1,22 +1,24 @@
 ---
-title: "Develop a Web-Based Self-Admitted Technical Debt Visualization and Management System"
-category: "Software & Architecture Analytics Projects"
 archived: false
-short: "In order to better manage technical debt, we need to design and develop a visualization and management system to help developers manage self-admitted technical debt."
-keywords:
-  - software engineering
-  - empirical studies
-  - self-admitted technical debt
-is_group: false
 available: true
-types:
-  - BSc
-  - MSc
+category: Software & Architecture Analytics Projects
+is_group: false
+keywords:
+- software engineering
+- empirical studies
+- self-admitted technical debt
 posted: 2023-01-01
+short: In order to better manage technical debt, we need to design and develop a visualization
+  and management system to help developers manage self-admitted technical debt.
 supervisors:
-  - Prof. dr. ir. Paris Avgeriou
-  - Dr. Mohamed A.M. Soliman
-  - Yikun Li
+- paris@cs.rug.nl
+- m.a.m.soliman@rug.nl
+- yikun.li@rug.nl
+title: Develop a Web-Based Self-Admitted Technical Debt Visualization and Management
+  System
+types:
+- BSc
+- MSc
 ---
 
 Technical debt refers to taking shortcuts, either deliberately or inadvertently, to achieve short-term goals, which might negatively influence the maintenance and evolution of software on the long term [2]. If technical debt is incurred immoderately and left unresolved, the accumulated technical debt can turn into maintenance burdens.

--- a/_sprojects/avgeriou-soliman-2.md
+++ b/_sprojects/avgeriou-soliman-2.md
@@ -1,22 +1,24 @@
 ---
-title: "Design and Implementation of a Technical Debt Monitoring System for PHP"
-category: "Software & Architecture Analytics Projects"
 archived: false
-short: "The Technical Debt Monitoring System would continuously monitor and track the technical debt incurred during software development by utilizing static code analysis tools such as SonarQube, specifically within the context of merge requests."
-keywords:
-  - software engineering
-  - empirical studies
-  - technical debt
-is_group: false
 available: true
-types:
-  - BSc
-  - MSc
+category: Software & Architecture Analytics Projects
+is_group: false
+keywords:
+- software engineering
+- empirical studies
+- technical debt
 posted: 2023-01-01
+short: The Technical Debt Monitoring System would continuously monitor and track the
+  technical debt incurred during software development by utilizing static code analysis
+  tools such as SonarQube, specifically within the context of merge requests.
 supervisors:
-  - Prof. dr. ir. Paris Avgeriou
-  - Dr. Mohamed A.M. Soliman
-  - Yikun Li
+- paris@cs.rug.nl
+- m.a.m.soliman@rug.nl
+- yikun.li@rug.nl
+title: Design and Implementation of a Technical Debt Monitoring System for PHP
+types:
+- BSc
+- MSc
 ---
 
 Technical debt refers to taking shortcuts, either deliberately or inadvertently, to achieve short-term goals, which might negatively influence the maintenance and evolution of software in the long term. If technical debt is incurred excessively and left unresolved, it can lead to increased maintenance costs and challenges.

--- a/_sprojects/capiluppi-3.md
+++ b/_sprojects/capiluppi-3.md
@@ -1,21 +1,22 @@
 ---
-title: "Extracting, Indexing and Listing Replication Packages from Past Research"
-category: "ML, NLP and Refactoring Projects 2022-23"
 archived: false
-short: "The objective of this work is to offer a streamlined approach to sharing replication packages for replication in empirical software engineering research."
-keywords:
-  - NLP
-  - machine learning
-  - secondary study
-is_group: false
 available: true
-types:
-  - BSc
-  - MSc Int
-  - MSc
+category: ML, NLP and Refactoring Projects 2022-23
+is_group: false
+keywords:
+- NLP
+- machine learning
+- secondary study
 posted: 2023-02-10
+short: The objective of this work is to offer a streamlined approach to sharing replication
+  packages for replication in empirical software engineering research.
 supervisors:
-  - Prof. Dr. Andrea Capiluppi
+- a.capiluppi@rug.nl
+title: Extracting, Indexing and Listing Replication Packages from Past Research
+types:
+- BSc
+- MSc Int
+- MSc
 ---
 
 The objective of this work is to offer a streamlined approach to sharing replication packages for replication in empirical software engineering research. Using a pull approach, instead of researchers being requested to push, we aim to increase the visibility and replicability of empirical results. These resources will be available as an additional service of an online repository.

--- a/_sprojects/feitosa-1.md
+++ b/_sprojects/feitosa-1.md
@@ -1,21 +1,21 @@
 ---
-title: Upgrade Design Pattern Detector and Quality Assessment
-short: This project entails the refactoring and upgrade (incl. dependencies'
-  update and small bug fixes) of both SSAP and Spoon-PttGrime.
 archived: false
-category: ML, NLP and Refactoring Projects 2022-23
-keywords:
-  - refactoring
-  - design patterns
-  - software analytics
-types:
-  - BSc
-  - MSc Int
-supervisors:
-  - Dr. Daniel Feitosa
-is_group: false
 available: false
+category: ML, NLP and Refactoring Projects 2022-23
+is_group: false
+keywords:
+- refactoring
+- design patterns
+- software analytics
 posted: 2023-02-10
+short: This project entails the refactoring and upgrade (incl. dependencies' update
+  and small bug fixes) of both SSAP and Spoon-PttGrime.
+supervisors:
+- d.feitosa@rug.nl
+title: Upgrade Design Pattern Detector and Quality Assessment
+types:
+- BSc
+- MSc Int
 ---
 
 The GoF (Gang-of-Four) **design patterns** (e.g., observer, command) are widely adopted in the industry as best practices and have well-investigated effects on software quality. However, not all instances of the same pattern are implemented equally. Deviations from the intended pattern structure (i.e., a buildup of elements such as classes unrelated to the pattern structure) are called **pattern grime** (or pollution). Among other side-effects, there is a correlation between the accumulation of grime and decreased levels of performance, security, and correctness of source code [1].

--- a/_sprojects/feitosa-2.md
+++ b/_sprojects/feitosa-2.md
@@ -1,21 +1,23 @@
 ---
-title: "Is Design Pattern Grime Related to Technical Debt?"
-category: "Software & Architecture Analytics Projects"
 archived: false
-short: "This project consists of an empirical study for mining pattern grime and TD items from open-source software (OSS) projects and correlating the presence of TD items in pattern instances with higher levels of pattern grime."
-keywords:
-  - mining software repositories
-  - empirical studies
-  - technical debt
-  - design patterns
-is_group: true
 available: true
-types:
-  - BSc
-  - MSc
+category: Software & Architecture Analytics Projects
+is_group: true
+keywords:
+- mining software repositories
+- empirical studies
+- technical debt
+- design patterns
 posted: 2023-02-10
+short: This project consists of an empirical study for mining pattern grime and TD
+  items from open-source software (OSS) projects and correlating the presence of TD
+  items in pattern instances with higher levels of pattern grime.
 supervisors:
-  - Dr. Daniel Feitosa
+- d.feitosa@rug.nl
+title: Is Design Pattern Grime Related to Technical Debt?
+types:
+- BSc
+- MSc
 ---
 
 The GoF (Gang-of-Four) design patterns (e.g., observer, command) are widely adopted in the industry as best practices and have well-investigated effects on software quality. However, not all instances of the same pattern are implemented equally. Deviations from the intended pattern structure (i.e., a buildup of elements such as classes unrelated to the pattern structure) are called pattern grime (or pollution). Among other side-effects, there is a correlation between the accumulation of grime and decreased levels of performance, security, and correctness of source code [1].

--- a/_sprojects/feitosa-3.md
+++ b/_sprojects/feitosa-3.md
@@ -1,20 +1,21 @@
 ---
-title: "Software Mining Rig: Building a Scalable MSR Infrastructure for Research"
-category: "Software & Architecture Analytics Projects 2022-23"
 archived: false
-short: "This project aims at building an MSR data collection infrastructure that can evolve and scale with minimum interruption."
-keywords:
-  - mining software repositories
-  - software analytics
-  - cloud infrastructure
-is_group: false
 available: true
-types:
-  - BSc
-  - MSc Int
+category: Software & Architecture Analytics Projects 2022-23
+is_group: false
+keywords:
+- mining software repositories
+- software analytics
+- cloud infrastructure
 posted: 2023-02-10
+short: This project aims at building an MSR data collection infrastructure that can
+  evolve and scale with minimum interruption.
 supervisors:
-  - Dr. Daniel Feitosa
+- d.feitosa@rug.nl
+title: 'Software Mining Rig: Building a Scalable MSR Infrastructure for Research'
+types:
+- BSc
+- MSc Int
 ---
 
 Mining Software Repositories (MSR) is an established research approach to extract generalizable knowledge from code-hosting platforms (e.g., GitHub and GitLab) and associated tools (e.g., issue trackers such as Jira, and email lists). Due to the scale of MSR studies (e.g., investigating thousands of repositories), tooling is a central piece of any method to reduce an already very time-consuming set of tasks. However, reusing tools between studies is not trivial and seldom happens in practice.

--- a/_sprojects/rastogi-1.md
+++ b/_sprojects/rastogi-1.md
@@ -1,19 +1,20 @@
 ---
-title: "How does software change?"
-category: "Software & Architecture Analytics Projects"
 archived: false
-short: "There are many parts of this project, offering interesting and challenging opportunities at the intersection of software engineering and artificial intelligence."
-keywords:
-  - software engineering
-  - empirical research
-  - data science
-is_group: false
 available: true
-types:
-  - MSc
+category: Software & Architecture Analytics Projects
+is_group: false
+keywords:
+- software engineering
+- empirical research
+- data science
 posted: 2023-01-01
+short: There are many parts of this project, offering interesting and challenging
+  opportunities at the intersection of software engineering and artificial intelligence.
 supervisors:
-  - Dr. Ayushi Rastogi
+- a.rastogi@rug.nl
+title: How does software change?
+types:
+- MSc
 ---
 
 As Lehman's first law of software evolution states: a [...] system must be continually adapted or it becomes progressively less satisfactory". With software systems shaping humans, it is increasingly important to understand their evolution.

--- a/_sprojects/rastogi-2.md
+++ b/_sprojects/rastogi-2.md
@@ -1,19 +1,22 @@
 ---
-title: "Fairness in Software Engineering"
-category: "Software & Architecture Analytics Projects 2022-23"
 archived: false
-short: "Join us in understanding the many ways in which development activities are unfair, the extent of the problem, and solutions to mitigate it. There are many interesting research problems here that will need software engineering and artificial intelligence-based solutions."
-keywords:
-  - software engineering
-  - empirical research
-  - data science
-is_group: false
 available: true
-types:
-  - MSc
+category: Software & Architecture Analytics Projects 2022-23
+is_group: false
+keywords:
+- software engineering
+- empirical research
+- data science
 posted: 2023-01-01
+short: Join us in understanding the many ways in which development activities are
+  unfair, the extent of the problem, and solutions to mitigate it. There are many
+  interesting research problems here that will need software engineering and artificial
+  intelligence-based solutions.
 supervisors:
-  - Dr. Ayushi Rastogi
+- a.rastogi@rug.nl
+title: Fairness in Software Engineering
+types:
+- MSc
 ---
 
 Fairness (and its opposite unfairness) plays a role in any process where decisions that affect others are made. For instance, unfairness negatively influences employee satisfaction and team performance at work. The problem gets critical in modern software projects, that rely on a global and diverse workforce more susceptible to unfairness.

--- a/_sprojects/rastogi-3.md
+++ b/_sprojects/rastogi-3.md
@@ -1,19 +1,20 @@
 ---
-title: "Missing Opportunities in Global Software Engineering"
-category: "Software & Architecture Analytics Projects 2022-23"
 archived: false
-short: "This project involves the identification of issues in global teams and/or ways to solve the problems experienced by global developers."
-keywords:
-  - software engineering
-  - empirical research
-  - data science
-is_group: false
 available: true
-types:
-  - MSc
+category: Software & Architecture Analytics Projects 2022-23
+is_group: false
+keywords:
+- software engineering
+- empirical research
+- data science
 posted: 2023-01-01
+short: This project involves the identification of issues in global teams and/or ways
+  to solve the problems experienced by global developers.
 supervisors:
-  - Dr. Ayushi Rastogi
+- a.rastogi@rug.nl
+title: Missing Opportunities in Global Software Engineering
+types:
+- MSc
 ---
 
 Software development penetrates national and geographical boundaries. With an increasingly diverse workforce and the global distribution of work, understanding missing opportunities in global software engineering is crucial.

--- a/_sprojects/rastogi-4.md
+++ b/_sprojects/rastogi-4.md
@@ -1,19 +1,21 @@
 ---
-title: "Exploratory Study On Emerging Digital Technologies In SMEs"
-category: "Software & Architecture Analytics Projects 2022-23"
 archived: false
-short: "In the project, researchers and students from different universities collaborate with practitioners from SMEs in a series of case studies in which the current state of affairs regarding emerging digital technologies is being explored."
-keywords:
-  - software engineering
-  - empirical research
-  - industry collaboration
-is_group: false
 available: true
-types:
-  - BSc
+category: Software & Architecture Analytics Projects 2022-23
+is_group: false
+keywords:
+- software engineering
+- empirical research
+- industry collaboration
 posted: 2023-01-01
+short: In the project, researchers and students from different universities collaborate
+  with practitioners from SMEs in a series of case studies in which the current state
+  of affairs regarding emerging digital technologies is being explored.
 supervisors:
-  - Dr. Ayushi Rastogi
+- a.rastogi@rug.nl
+title: Exploratory Study On Emerging Digital Technologies In SMEs
+types:
+- BSc
 ---
 
 Do you want to graduate in a larger project together with other researchers? And perform research at several SMEs? And do you want to dive into the backgrounds of new, innovative digital technology? Then do your graduation assignment at the 'Digital innovation in SMEs' program, a collaboration of three Universities of Applied Sciences, two universities and a consortium of SME organizations.

--- a/_sprojects/soliman-1.md
+++ b/_sprojects/soliman-1.md
@@ -1,23 +1,26 @@
 ---
-title: "Exploring Architectural Knowledge in Open Source Systems"
-category: "Software & Architecture Analytics Projects 2022-23"
 archived: false
-short: "This research effort includes the identification of relevant architectural knowledge, the analysis of the distribution of architectural knowledge in open source systems, and the development of a tool to support software engineers to find relevant architectural knowledge."
-keywords:
-  - Architectural Knowledge
-  - Architectural Design Decisions
-  - Information Retrieval
-  - Open source systems
-is_group: false
 available: true
-types:
-  - MSc
-  - BSc
-  - Int
+category: Software & Architecture Analytics Projects 2022-23
+is_group: false
+keywords:
+- Architectural Knowledge
+- Architectural Design Decisions
+- Information Retrieval
+- Open source systems
 posted: 2023-02-10
+short: This research effort includes the identification of relevant architectural
+  knowledge, the analysis of the distribution of architectural knowledge in open source
+  systems, and the development of a tool to support software engineers to find relevant
+  architectural knowledge.
 supervisors:
-  - Dr. Mohamed A.M. Soliman
-  - Prof. dr. ir. Paris Avgeriou
+- m.a.m.soliman@rug.nl
+- paris@cs.rug.nl
+title: Exploring Architectural Knowledge in Open Source Systems
+types:
+- MSc
+- BSc
+- Int
 ---
 
 Software architectural design decisions (ADDs) play a crucial role when developing a software system [1]. However, making the right ADDs is a challenging task, which requires knowledge and expertise. Sharing and re-using architectural knowledge from existing systems could support software engineers to learn from previous design experiences. This would be useful for software engineers to re-use successful ADDs from other existing software systems.

--- a/_sprojects/storm-1.md
+++ b/_sprojects/storm-1.md
@@ -1,19 +1,20 @@
 ---
-title: "Domain-specific Spreadsheet Languages and Tools"
-category: "Language Engineering Projects"
 archived: false
-short: "The goal of this project is to explore how Rascal can support the definition of domain-specific spreadsheet languages."
-keywords:
-  - language engineering
-  - spreadsheets
-  - end-user programming
-is_group: false
 available: true
-types:
-  - MSc
+category: Language Engineering Projects
+is_group: false
+keywords:
+- language engineering
+- spreadsheets
+- end-user programming
 posted: 2023-02-10
+short: The goal of this project is to explore how Rascal can support the definition
+  of domain-specific spreadsheet languages.
 supervisors:
-  - Prof. dr. Tijs van der Storm
+- storm@cwi.nl
+title: Domain-specific Spreadsheet Languages and Tools
+types:
+- MSc
 ---
 
 [Rascal](http://www.rascal-mpl.org/) is a meta programming language and language workbench for developing source code analysis and transformation tools. This includes compilers for programming languages and DSLs. Currently, Rascal can be considered a textual language workbench since it takes plain-text source code as input and produces various kinds of output.

--- a/_sprojects/storm-2.md
+++ b/_sprojects/storm-2.md
@@ -1,21 +1,24 @@
 ---
-title: "M3Solidity: M3 Source Code Model for Ethereum Solidity"
-category: "Software & Architecture Analytics Projects"
 archived: false
-short: "The goal of this project is provide an M3 bridge to the Ethereum Solidity language. This will enable analysis and reverse engineering of Smart Contracts running on the Ethereum blockchain."
-keywords:
-  - source code analysis
-  - M3
-  - Rascal
-  - smart contracts
-is_group: false
 available: true
-types:
-  - BSc
+category: Software & Architecture Analytics Projects
+is_group: false
+keywords:
+- source code analysis
+- M3
+- Rascal
+- smart contracts
 posted: 2023-01-01
+short: The goal of this project is provide an M3 bridge to the Ethereum Solidity language.
+  This will enable analysis and reverse engineering of Smart Contracts running on
+  the Ethereum blockchain.
 supervisors:
-  - Prof. dr. Tijs van der Storm
+- storm@cwi.nl
+title: 'M3Solidity: M3 Source Code Model for Ethereum Solidity'
+types:
+- BSc
 ---
+
 Rascal is a language workbench and environment for source code analysis and transformation. One library component of Rascal is *M3* a general model to represent facts about source code. It includes information on files, classes, ASTs, name binding, type relations, containment, and optionally inheritance, call graphs etc. Currently, the model has been instantiated for Java, Javascript, and CSharp. The goal of this project is provide an M3 bridge to the Ethereum Solidity language. This will enable analysis and reverse engineering of Smart Contracts running on the Ethereum blockchain.
 
 Deliverables:

--- a/_sprojects/storm-3.md
+++ b/_sprojects/storm-3.md
@@ -1,20 +1,21 @@
 ---
-title: "Embedding Diagram Editors into Salix"
-category: "Language Engineering Projects"
 archived: false
-short: "The goal of this project is to investigate how to embed Web-based diagram editor frameworks into the Salix model for defining UIs."
-keywords:
-  - language engineering
-  - graphical modeling
-  - Javascript
-  - Rascal
-is_group: false
 available: true
-types:
-  - BSc
+category: Language Engineering Projects
+is_group: false
+keywords:
+- language engineering
+- graphical modeling
+- Javascript
+- Rascal
 posted: 2023-02-10
+short: The goal of this project is to investigate how to embed Web-based diagram editor
+  frameworks into the Salix model for defining UIs.
 supervisors:
-  - Prof. dr. Tijs van der Storm
+- storm@cwi.nl
+title: Embedding Diagram Editors into Salix
+types:
+- BSc
 ---
 
 [Salix](https://github.com/cwi-swat/salix) is a framework in Rascal for defining immediate mode, web-based UIs. It follows the Elm model where an application is defined using a view function and an model update function.

--- a/_sprojects/storm-4.md
+++ b/_sprojects/storm-4.md
@@ -1,20 +1,20 @@
 ---
-title: "Hybrid Partial Evaluation for Javascript"
-category: "Language Engineering Projects"
 archived: false
-short: ""
-keywords:
-  - language engineering
-  - partial evaluation
-  - compilation
-  - interpreters
-is_group: false
 available: true
-types:
-  - MSc
+category: Language Engineering Projects
+is_group: false
+keywords:
+- language engineering
+- partial evaluation
+- compilation
+- interpreters
 posted: 2023-02-10
+short: ''
 supervisors:
-  - Prof. dr. Tijs van der Storm
+- storm@cwi.nl
+title: Hybrid Partial Evaluation for Javascript
+types:
+- MSc
 ---
 
 Partial evaluation is a technique for optimizing interpreters of programming languages. It works by fixing one of the arguments to the intepreter (i.e., the program), but leaving other parameters open (i.e., the dynamic input). A partial evaluator then "executes" the program, evaluating as much as possible. Partial evaluation is a well-research topic, both theoretically, and practically. A recent technique that claims to solve one of the problems of partial evaluation (e.g., code explosion) is Hybrid Partial Evaluation (see reference below). This original work is based on class-based OO languages (i.e., Java). The goal of this project is to transfer the idea of Hybrid partial evaluation to Javascript.

--- a/_sprojects/storm-5.md
+++ b/_sprojects/storm-5.md
@@ -1,21 +1,22 @@
 ---
-title: "Extracting a Rascal Grammar from the Swift Reference Manual"
-category: "Language Engineering Projects"
 archived: false
-short: "In this project the goal is to obtain a high quality Rascal grammar from the Swift language reference, in a (semi-)automatic, traceable way."
-keywords:
-  - language engineering
-  - grammarware
-  - Rascal
-  - Swift
-  - reverse engineering
-is_group: false
 available: true
-types:
-  - BSc
+category: Language Engineering Projects
+is_group: false
+keywords:
+- language engineering
+- grammarware
+- Rascal
+- Swift
+- reverse engineering
 posted: 2023-01-01
+short: In this project the goal is to obtain a high quality Rascal grammar from the
+  Swift language reference, in a (semi-)automatic, traceable way.
 supervisors:
-  - Prof. dr. Tijs van der Storm
+- storm@cwi.nl
+title: Extracting a Rascal Grammar from the Swift Reference Manual
+types:
+- BSc
 ---
 
 Grammars are an essential component of many meta programming scenarios, such as static analysis, mass maintenance, and refactoring. In this project the goal is to obtain a high quality [Rascal](http://www.rascal-mpl.org/) grammar from the Swift language reference, in a (semi-)automatic, traceable way. In particular, we're interested in the grammar transformation steps needed to go from a "documentation" grammar, to a grammar that can be used for parsing.

--- a/_sprojects/storm-6.md
+++ b/_sprojects/storm-6.md
@@ -1,20 +1,22 @@
 ---
-title: "Implementing Nick Szabo's Contract Language"
-category: "Language Engineering Projects"
 archived: false
-short: "Some time ago, Nick Szabo wrote an essay exploring how a language for smart contracts could look like. The goal of this project is to go one step further to define a proper semantics and implementation of a language like this."
-keywords:
-  - language engineering
-  - block chain
-  - DSLs
-  - contracts
-is_group: false
 available: true
-types:
-  - MSc
+category: Language Engineering Projects
+is_group: false
+keywords:
+- language engineering
+- block chain
+- DSLs
+- contracts
 posted: 2023-01-01
+short: Some time ago, Nick Szabo wrote an essay exploring how a language for smart
+  contracts could look like. The goal of this project is to go one step further to
+  define a proper semantics and implementation of a language like this.
 supervisors:
-  - Prof. dr. Tijs van der Storm
+- storm@cwi.nl
+title: Implementing Nick Szabo's Contract Language
+types:
+- MSc
 ---
 
 Smart contracts are little programs that run on blockchain-like distributed ledger platforms. Typically, e.g., as on the Ethereum platform, such languages are extensions of general purpose languages, such as Javascript. As a result, the contracts written in these languages are hard to analyze and validate.

--- a/_sprojects/storm-7.md
+++ b/_sprojects/storm-7.md
@@ -1,19 +1,21 @@
 ---
-title: "CodeBuff in Rascal"
-category: "Language Engineering Projects"
 archived: false
-short: "CodeBuff has been implemented in the context of the ANTLR parse generator, and uses its internal parse tree data structures for learning and formatting. We're interested in transferring CodeBuff to the context of the Rascal language workbench."
-keywords:
-  - language engineering
-  - pretty printing
-  - machine learning
-is_group: false
 available: true
-types:
-  - BSc
+category: Language Engineering Projects
+is_group: false
+keywords:
+- language engineering
+- pretty printing
+- machine learning
 posted: 2023-01-01
+short: CodeBuff has been implemented in the context of the ANTLR parse generator,
+  and uses its internal parse tree data structures for learning and formatting. We're
+  interested in transferring CodeBuff to the context of the Rascal language workbench.
 supervisors:
-  - Prof. dr. Tijs van der Storm
+- storm@cwi.nl
+title: CodeBuff in Rascal
+types:
+- BSc
 ---
 
 Pretty printing is one aspect of language engineering that's often overlooked, but nevertheless important. Unfortunately, developing a (good) pretty printer is very hard. For instance, Bob Nystrom, of Google, called his Dart formatter, ["the hardest program I've ever written"](http://journal.stuffwithstuff.com/2015/09/08/the-hardest-program-ive-ever-written/).

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -84,14 +84,16 @@ collections:
         required: false
         collection: "team"
         value_field: "contact.email"
-        search_fields: ["title", "contact.email"]
+        display_fields: ["title"]
+        search_fields: ["title"]
         multiple: true
       - name: "lecturers"
         widget: "relation"
         required: false
         collection: "team"
         value_field: "contact.email"
-        search_fields: ["title", "contact.email"]
+        search_fields: ["title"]
+        display_fields: ["title"]
         multiple: true
       - name: "external_coordinators"
         widget: "list"
@@ -127,7 +129,8 @@ collections:
         widget: "relation"
         collection: "team"
         value_field: "contact.email"
-        search_fields: ["title", "contact.email"]
+        search_fields: ["title"]
+        display_fields: ["title"]
         multiple: true
       - name: "funding"
         widget: "list"
@@ -161,7 +164,8 @@ collections:
         widget: "relation"
         collection: "team"
         value_field: "contact.email"
-        search_fields: ["title", "contact.email"]
+        search_fields: ["title"]
+        display_fields: ["title"]
         multiple: true
       - { name: "is_group", widget: "boolean" }
       - { name: "available", widget: "boolean" }

--- a/admin/config.yml
+++ b/admin/config.yml
@@ -83,15 +83,15 @@ collections:
         widget: "relation"
         required: false
         collection: "team"
-        value_field: "title"
-        search_fields: ["title"]
+        value_field: "contact.email"
+        search_fields: ["title", "contact.email"]
         multiple: true
       - name: "lecturers"
         widget: "relation"
         required: false
         collection: "team"
-        value_field: "title"
-        search_fields: ["title"]
+        value_field: "contact.email"
+        search_fields: ["title", "contact.email"]
         multiple: true
       - name: "external_coordinators"
         widget: "list"
@@ -126,8 +126,8 @@ collections:
       - name: "members"
         widget: "relation"
         collection: "team"
-        value_field: "title"
-        search_fields: ["title"]
+        value_field: "contact.email"
+        search_fields: ["title", "contact.email"]
         multiple: true
       - name: "funding"
         widget: "list"
@@ -160,8 +160,8 @@ collections:
       - name: "supervisors"
         widget: "relation"
         collection: "team"
-        value_field: "title"
-        search_fields: ["title"]
+        value_field: "contact.email"
+        search_fields: ["title", "contact.email"]
         multiple: true
       - { name: "is_group", widget: "boolean" }
       - { name: "available", widget: "boolean" }


### PR DESCRIPTION
This PR refactors member relations so they use the `contact.email` field instead the `title` field as foreign key. 
 - CMS configuration var updated accordingly
 - Frontend was updated to access member correctly
 - All collection entries with a member relation was updated to use the correct email

Emails work better for foreign keys as they are less likely to change compared to title. 